### PR TITLE
fix: cropped profile picture and excess padding on Google Chrome browser and Lenovo Thinkpad T470s and similar devices

### DIFF
--- a/app/(root)/page.tsx
+++ b/app/(root)/page.tsx
@@ -17,7 +17,7 @@ import { pagesConfig } from "@/config/pages";
 import { siteConfig } from "@/config/site";
 import { featuredSkills } from "@/config/skills";
 import { cn } from "@/lib/utils";
-import namanImg from "@/public/naman-img.jpg";
+const namanImg = "/naman-img.jpg";
 
 export const metadata: Metadata = {
   title: `${pagesConfig.home.metadata.title} | Modern Next.js Developer Portfolio Template`,
@@ -71,14 +71,14 @@ export default function IndexPage() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(softwareSchema) }}
       />
 
-      <section className="space-y-6 pb-8 pt-6 mb-0 md:pb-12 md:py-20 lg:py-32 h-screen flex items-center">
-        <div className="container flex max-w-[64rem] flex-col items-center gap-4 text-center -mt-20">
+      <section className="space-y-6 py-6 flex items-center justify-center min-h-[70vh]">
+        <div className="flex flex-col items-center text-center gap-4 max-w-[64rem]">
           <Image
             src={namanImg}
-            height={100}
-            width={100}
+            height={160}
+            width={160}
             sizes="100vw"
-            className="bg-primary rounded-full mb-0 h-auto md:mb-2 w-[60%] max-w-[16rem] border-8 border-primary"
+            className="rounded-full aspect-square object-cover border-8 border-primary"
             alt="Naman Barkiya - Full Stack Developer Portfolio"
             priority
           />
@@ -103,7 +103,7 @@ export default function IndexPage() {
             </p>
           </div>
 
-          <div className="flex flex-col mt-10 items-center justify-center sm:flex-row sm:space-x-4 gap-3">
+          <div className="flex flex-col mt-6 items-center justify-center sm:flex-row sm:space-x-4 gap-3">
             <AnimatedText delay={0.6}>
               <Link
                 href={"https://github.com/namanbarkiya"}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -98,7 +98,7 @@ export const metadata = {
 export default function RootLayout({ children }: RootLayoutProps) {
   const GA_ID = process.env.NEXT_PUBLIC_GOOGLE_MEASUREMENT_ID;
   if (!GA_ID) {
-    throw new Error("Missing Google Analytics ID");
+    console.warn("Google Analytics ID is missing. GA will not be loaded.");
   }
 
   return (
@@ -131,7 +131,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
           <ModalProvider />
         </ThemeProvider>
       </body>
-      <GoogleAnalytics gaId={GA_ID} />
+      {GA_ID && <GoogleAnalytics gaId={GA_ID} />}
     </html>
   );
 }


### PR DESCRIPTION
- Added object-cover and aspect-square so that images are not cropped on Google Chrome browser and Lenovo Thinkpad T470s and similar devices

- Adjusted padding so that GitHub & Contact buttons are visible at 100% zoom on Google Chrome browser and Lenovo Thinkpad T470s and similar devices

Screenshoot:
<img width="958" alt="image" src="https://github.com/user-attachments/assets/28cc137e-223f-4643-a869-f88019cd3e49" />


closes #1
