### PR TITLE
fix demo site link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A modern, responsive, and SEO-optimized **Next.js 14 portfolio template** design
 
 ## 🚀 Demo
 
-View the live demo at [https://nbarkiya.xyz/](nbarkiya.xyz)
+View the live demo at [https://nbarkiya.xyz/](https://nbarkiya.xyz)
 
 https://github.com/namanbarkiya/minimal-next-portfolio/assets/82203888/f93bf5ca-c2bd-4fe5-a413-1050ebf6cf78
 


### PR DESCRIPTION
Currently the demo site link is taking users to a [bad link](https://github.com/namanbarkiya/minimal-next-portfolio/blob/master/nbarkiya.xyz) because it's missing protocol. This PR fixes the link so users are directed to the correct website at https://nbarkiya.xyz